### PR TITLE
allowing the 1 replica to be suspended seems like it causes huge dela…

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -19,7 +19,7 @@ kill_timeout = "5s"
   force_https = true
   auto_stop_machines = "suspend"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ["app"]
 
   [http_service.concurrency]


### PR DESCRIPTION
…y on first request, so setting min to 1 to see if this avoids the issue

app logs don't suggest that the latency is coming from the app... seems quick (time from machine start to request served)